### PR TITLE
Add sdl build info for Arch Linux

### DIFF
--- a/content/en/installation/sdl2.md
+++ b/content/en/installation/sdl2.md
@@ -13,6 +13,12 @@ weight: -10
 $ sudo apt install libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev
 ```
 
+### Arch Linux
+
+```shell
+sudo pacman -S sdl2_image sdl2_ttf
+```
+
 ### MacOS
 
 ```shell


### PR DESCRIPTION
This PR adds build dependencies information for sdl2 build on Arch Linux.