### PR TITLE
Update command names

### DIFF
--- a/content/en/usage/usage.md
+++ b/content/en/usage/usage.md
@@ -68,7 +68,7 @@ There are also the commands:
 |:-------:|:-------:|:-------------------------------------------------------------------------:|
 | `project-kill-buffers` | `C-x p K` | delete all this project's buffers                    |
 | `project-root` |                     | display the project root         |
-| `project-find-file-other-window` | `C-x 4 p f` | open a file in another window              |
+| `project-find-file-next-window` | `C-x 4 p f` | open a file in another window              |
 | `project-root-directory` | `C-x p d` | open the project root with Lem's directory-mode      |
 | `project-root-directory-other-window` |  | open the project root in another window          |
 

--- a/content/en/usage/usage.md
+++ b/content/en/usage/usage.md
@@ -66,7 +66,7 @@ There are also the commands:
 
 | Command | Key-combination | Function                                                        |
 |:-------:|:-------:|:-------------------------------------------------------------------------:|
-| `project-delete-buffers` | `C-x p K` | delete all this project's buffers                    |
+| `project-kill-buffers` | `C-x p K` | delete all this project's buffers                    |
 | `project-root` |                     | display the project root         |
 | `project-find-file-other-window` | `C-x 4 p f` | open a file in another window              |
 | `project-root-directory` | `C-x p d` | open the project root with Lem's directory-mode      |
@@ -83,7 +83,7 @@ These commands allow to **switch** between projects:
 
 Configuration:
 
-- for `project-delete-buffers`:
+- for `project-kill-buffers`:
   - if `*delete-repl-buffer*` is non t, we don't delete the REPL buffer.
   - if `*delete-last-buffer*` is non nil, we will delete the last buffer. This would cause Lem to exit.
 

--- a/content/en/usage/usage.md
+++ b/content/en/usage/usage.md
@@ -70,7 +70,7 @@ There are also the commands:
 | `project-root` |                     | display the project root         |
 | `project-find-file-next-window` | `C-x 4 p f` | open a file in another window              |
 | `project-root-directory` | `C-x p d` | open the project root with Lem's directory-mode      |
-| `project-root-directory-other-window` |  | open the project root in another window          |
+| `project-root-directory-next-window` |  | open the project root in another window          |
 
 These commands allow to **switch** between projects:
 


### PR DESCRIPTION
Hi
Some commands have been changed of name
- project-delete-buffers -> project-kill-buffers
- project-find-file-other-window -> project-find-file-next-window
- project-root-directory-other-window -> project-root-directory-next-window