### PR TITLE
adding micros, lem-base16-themes, lem-mailbox repos to fix installati…

### DIFF
--- a/content/en/installation/getting-started.md
+++ b/content/en/installation/getting-started.md
@@ -64,6 +64,9 @@ You can put the files in `$HOME/common-lisp` or in the quicklisp location `$HOME
 $ mkdir $HOME/common-lisp
 $ cd $HOME/common-lisp
 $ git clone --recursive https://github.com/lem-project/lem.git
+$ git clone --recursive https://github.com/lem-project/micros
+$ git clone --recursive https://github.com/lukpank/lem-base16-themes
+$ git clone --recursive https://github.com/lem-project/lem-mailbox
 ```
 You can start "lem" using the following command.
 ```


### PR DESCRIPTION
adding more repos to the sbcl installation of lem

when installing lem with sbcl we net not only the lem repos to be into the quicklisp/local-projects but also micros, lem-base16-themes repos lem-mailbox as well.